### PR TITLE
Supporting older Bravia KDL models with wake on lan

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ After [Homebridge](https://github.com/nfarina/homebridge) has been installed:
 	         "name": "TV 2",
           "interval": 10,
           "ipadress": "192.168.1.2",
+          "wakeOnLan": true,
           "port": 80,
           "psk": "PSKHERE",
           "extraInputs": false,
@@ -97,6 +98,7 @@ After [Homebridge](https://github.com/nfarina/homebridge) has been installed:
 | ipadress | **Yes** | IP adress from your Sony Bravia Android TV |
 | port | No | If you have problems with connecting to the TV, try a different port _(Default: 80)_ |
 | psk | **Yes** | Your PRE SHARED KEY _(see preparing the TV above)_ |
+| wakeOnLan | **No** | Use `wake_on_lan` to turn on the TV (needed for old Bravia KDL) _(Default: false)_ |
 | interval | **No** | Polling interval _(Default: 10s)_ |
 | extraInputs | **No** | Inputs for "Scart, Composite, Wifidisplay" _(Default: false)_ |
 | cecInputs | **No** | Inputs for connected cec devices like Apple TV _(Default: false)_ |

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "node-persist": "0.0.8",
-    "async": "2.6.0"
+    "async": "2.6.0",
+    "wake_on_lan": "*"
   }
 }

--- a/src/platform.js
+++ b/src/platform.js
@@ -34,6 +34,7 @@ function BraviaOSPlatform (log, config, api) {
       name: this.config.tvs[i].name||'TV ' + i,
       interval: (this.config.tvs[i].interval*1000)||10000,
       ipadress: this.config.tvs[i].ipadress,
+      wakeOnLan: this.config.tvs[i].wakeOnLan || false,
       port: this.config.tvs[i].port||80,
       psk: this.config.tvs[i].psk,
       extraInputs: this.config.tvs[i].extraInputs||false,
@@ -41,7 +42,8 @@ function BraviaOSPlatform (log, config, api) {
       cecInputs: this.config.tvs[i].cecInputs||false,
       favApps: this.config.tvs[i].favApps||false
     };
-    if(this.config.tvs[i].intervall<10000){
+    
+    if(this.config.tvs[i].interval<10000){
       self.logger.warn('Critical interval value. Setting interval to 10s for ' + this.config.tvs[i].name);
       this.config.tvs[i].interval = 10000;
     }


### PR DESCRIPTION
This pull request aims at integrating older Sony KDL models that cannot be turned ON via REST API (see Issue #14). The configuration of the plugin now provides an additional field `wakeOnLan` that, if set to `true`,  allow the plugin to use `wake_on_lan` to turn ON the television.

This pull request also provides a fix for older models that do not correctly show the name of the CEC devices (e.g. Playstation 4) connected to the television by showing the `label` instead of the `title` when the former is available.

Tested with BRAVIA KDL-48W605.

Summary of Changes:
- Add `wake_on_lan` dependency to plugin
- Change README with `wakeOnLan` field
- Use `label` instead of `title` (when defined) to name a CEC input in order to show the correct connected device name (e.g. Playstation 4)
- Minor refactoring and extraction of `removeEntries` method in `accessory.js`