### PR TITLE
Change info button to display

### DIFF
--- a/src/accessory.js
+++ b/src/accessory.js
@@ -704,7 +704,7 @@ class TelevisionAccessory {
         case 15:
     
           this.logger.info(this.accessory.displayName + ': Info');
-          await this.Bravia.setIRCC('AAAAAgAAAMQAAABNAw==');
+          await this.Bravia.setIRCC('AAAAAQAAAAEAAAA6Aw==');
     
           break;
       


### PR DESCRIPTION
Currently the info button opens help, to me this does not seem useful.
Propose change to Display (AAAAAQAAAAEAAAA6Aw==), this will show the current channel info.