### PR TITLE
Use input label when defined

### DIFF
--- a/src/accessory.js
+++ b/src/accessory.js
@@ -181,10 +181,11 @@ class TelevisionAccessory {
       inputs.map( input => {
   
         const isTitleValid = input.title && input.title.length > 0;
-        this._inputs.set((isTitleValid ? input.title : input.title), input.uri);
+        const isLabelValid = input.label && input.label.length > 0;
+        
+        this._inputs.set((isLabelValid ? input.label : input.title), input.uri);
         this._sourceType.set((isTitleValid ? input.title : input.label), input.sourceType);
         this._deviceType.set((isTitleValid ? input.title : input.label), input.deviceType);
-
       });
       
       await this._removeInputs(true);

--- a/src/accessory.js
+++ b/src/accessory.js
@@ -180,9 +180,10 @@ class TelevisionAccessory {
   
       inputs.map( input => {
   
-        this._inputs.set((input.label ? input.label : input.title), input.uri);
-        this._sourceType.set((input.title ? input.title : input.label), input.sourceType);
-        this._deviceType.set((input.title ? input.title : input.label), input.deviceType);
+        const isTitleValid = input.title && input.title.length > 0;
+        this._inputs.set((isTitleValid ? input.title : input.title), input.uri);
+        this._sourceType.set((isTitleValid ? input.title : input.label), input.sourceType);
+        this._deviceType.set((isTitleValid ? input.title : input.label), input.deviceType);
 
       });
       

--- a/src/accessory.js
+++ b/src/accessory.js
@@ -180,7 +180,7 @@ class TelevisionAccessory {
   
       inputs.map( input => {
   
-        this._inputs.set((input.title ? input.title : input.label), input.uri);
+        this._inputs.set((input.label ? input.label : input.title), input.uri);
         this._sourceType.set((input.title ? input.title : input.label), input.sourceType);
         this._deviceType.set((input.title ? input.title : input.label), input.deviceType);
 


### PR DESCRIPTION
This pull request introduces two small fixes:

1 - In the current version, the name of an input is set as follows:
```
this._inputs.set((input.title ? input.title : input.label), input.uri);
```
However, when retrieving inputs, `input.title` and `input.label` are always defined and eventually mapped to an empty string. In doing so, `input.title ?` is always true. In this version, `title` and `label` need to be both defined and non-empty.

2 - Devices like Sony PS4 use `label` instead of `title` to set the actual device's name. For example,  in the Italian version, a  PS4 connected to an HDMI port has `label = "Playstation 4"` and `title = "Lettore 1`". In this pull request, when handling inputs, if the `label` is defined and non empty, it is used instead of `title`.

