### PR TITLE
check speaker result before usage

### DIFF
--- a/src/accessories/accessory.handler.js
+++ b/src/accessories/accessory.handler.js
@@ -72,8 +72,9 @@ class Handler {
         const response = await this.bravia.exec('audio', 'getVolumeInformation');
         logger.debug(response, `${this.accessory.displayName} Speaker`);
 
-        const targetSpeaker = response.result[0].find((speaker) => speaker.target === target);
-        const availableTargets = response.result[0].map((speaker) => {
+        const speakers = (response.result && response.result.length) ? response.result[0] : [];
+        const targetSpeaker = speakers.find((speaker) => speaker.target === target);
+        const availableTargets = speakers.map((speaker) => {
           return speaker.target;
         });
 


### PR DESCRIPTION
This PR fixes the following TypeError by checking for response.result[0] before using it:
```
TypeError: response.result[0].find is not a function
    at Handler.getSpeakerState (/usr/lib/node_modules/homebridge-bravia-tvos/src/accessories/accessory.handler.js:75:50)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at Handler.poll (/usr/lib/node_modules/homebridge-bravia-tvos/src/accessories/accessory.handler.js:562:9)
```