### PR TITLE
Fix grammar and add display name

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ You need to put the PSK entered in your tv also in your config.json.
  
 | **Attributes** | **Required** | **Usage** | **Default** | **Options** |
 |----------------|--------------|-----------|-------------|-------------|
-| inputs.name | **X** | Name for the channel to display in the tv inputs list
+| inputs.name | **X** | Name for the channel to display in the TV inputs list
 | inputs.identifier | **X** | Exact name of the input (eg HDMI 1)
 | inputs.source | **X** | Type of the tv input |  | `cec`, `component`, `composite`, `hdmi`, `scart`, `widi`
 
@@ -233,14 +233,14 @@ You need to put the PSK entered in your tv also in your config.json.
  
 | **Attributes** | **Required** | **Usage** | **Default** | **Options** |
 |----------------|--------------|-----------|-------------|-------------|
-| apps.name | **X** | Name for the application to display in the tv inputs list
+| apps.name | **X** | Name for the application to display in the TV inputs list
 | apps.identifier | **X** | Exact name of the Application
 
  ## Options TV Channels
  
 | **Attributes** | **Required** | **Usage** | **Default** | **Options** |
 |----------------|--------------|-----------|-------------|-------------|
-| channels.name | **X** | Name for the channel to display in the tv inputs list
+| channels.name | **X** | Name for the channel to display in the TV inputs list
 | channels.channel | **X** | Number of the channel as seen on the TV.
 | channels.source | **X** | Source of the channel. |  | `dvbt`, `dvbc`, `dvbs`, `isdbt`, `isdbc`, `atsct`, `isdbs`, `analog`
 
@@ -248,14 +248,14 @@ You need to put the PSK entered in your tv also in your config.json.
  
 | **Attributes** | **Required** | **Usage** | **Default** | **Options** |
 |----------------|--------------|-----------|-------------|-------------|
-| commands.name | **X** | Name for the command to display in the tv inputs list
+| commands.name | **X** | Name for the command to display in the TV inputs list
 | commands.value | **X** | IRCC code or name of the command to display in Apple Home. (eg. "AAAAAQAAAAEAAABgAw==" or "PowerOff")
 
  ## Options TV Macros
  
 | **Attributes** | **Required** | **Usage** | **Default** | **Options** |
 |----------------|--------------|-----------|-------------|-------------|
-| macros.name | **X** | Name for the macro to display in the tv inputs list
+| macros.name | **X** | Name for the macro to display in the TV inputs list
 | macros.delay |  | Delay between sending commands (in ms). (Default 1000ms)
 | macros.commands | **X** | An array of IRCC codes/names to perform the macro
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -162,7 +162,7 @@
                 "name": {
                   "title": "Name",
                   "type": "string",
-                  "description": "Name for the channel to display in the tv inputs list",
+                  "description": "Name for the channel to display in the TV inputs list",
                   "required": true
                 },
                 "identifier": {
@@ -216,7 +216,7 @@
                 "name": {
                   "title": "Name",
                   "type": "string",
-                  "description": "Name for the application to display in the tv inputs list",
+                  "description": "Name for the application to display in the TV inputs list",
                   "required": true
                 },
                 "identifier": {
@@ -238,7 +238,7 @@
                 "name": {
                   "title": "Name",
                   "type": "string",
-                  "description": "Name for the channel to display in the tv inputs list",
+                  "description": "Name for the channel to display in the TV inputs list",
                   "required": true
                 },
                 "channel": {
@@ -300,7 +300,7 @@
                 "name": {
                   "title": "Name",
                   "type": "string",
-                  "description": "Name for the command to display in the tv inputs list",
+                  "description": "Name for the command to display in the TV inputs list",
                   "required": true
                 },
                 "value": {

--- a/homebridge-ui/ui/src/mixins/homebridge.mixin.js
+++ b/homebridge-ui/ui/src/mixins/homebridge.mixin.js
@@ -67,7 +67,7 @@ export default {
               name: {
                 title: 'Name',
                 type: 'string',
-                description: 'Name for the channel to display in the tv inputs list',
+                description: 'Name for the channel to display in the TV inputs list',
                 required: true,
               },
               channel: {
@@ -256,7 +256,7 @@ export default {
               name: {
                 title: 'Name',
                 type: 'string',
-                description: 'Name for the channel to display in the tv inputs list',
+                description: 'Name for the channel to display in the TV inputs list',
                 required: true,
               },
               identifier: {

--- a/homebridge-ui/ui/src/utils/config.schema.js
+++ b/homebridge-ui/ui/src/utils/config.schema.js
@@ -155,7 +155,7 @@ export default {
               name: {
                 title: 'Name',
                 type: 'string',
-                description: 'Name for the input to display in the tv inputs list',
+                description: 'Name for the input to display in the TV inputs list',
                 required: true,
               },
               identifier: {
@@ -178,7 +178,7 @@ export default {
               name: {
                 title: 'Name',
                 type: 'string',
-                description: 'Name for the application to display in the tv inputs list',
+                description: 'Name for the application to display in the TV inputs list',
                 required: true,
               },
               identifier: {
@@ -201,7 +201,7 @@ export default {
               name: {
                 title: 'Name',
                 type: 'string',
-                description: 'Name for the channel to display in the tv inputs list',
+                description: 'Name for the channel to display in the TV inputs list',
                 required: true,
               },
               identifier: {
@@ -224,7 +224,7 @@ export default {
               name: {
                 title: 'Name',
                 type: 'string',
-                description: 'Name for the command to display in the tv inputs list',
+                description: 'Name for the command to display in the TV inputs list',
                 required: true,
               },
               value: {

--- a/homebridge-ui/ui/src/views/Config.vue
+++ b/homebridge-ui/ui/src/views/Config.vue
@@ -10,7 +10,7 @@
     #nav
       router-link(to="/") Home
       span(style="font-weight: bold !important;")  · 
-      router-link(to="/config" v-b-popover.hover.top="'This is the old (static) config.schema! With this it is not possible to dynamically display the inputs for a TV. Only for experienced.'" title="Attention") Configs
+      router-link(to="/config" v-b-popover.hover.top="'This is the old (static) config.schema! With this it is not possible to dynamically display the inputs for a TV. Only for experienced users.'" title="Attention") Configs
       span(style="font-weight: bold !important;")  · 
       router-link(to="/new") New
 </template>

--- a/homebridge-ui/ui/src/views/Home.vue
+++ b/homebridge-ui/ui/src/views/Home.vue
@@ -14,7 +14,7 @@
       .mt-3.mb-2.text-muted Homebridge plugin for Sony Bravia Android TVs.
       b-link.github-link(href="https://github.com/SeydX/homebridge-bravia-tvos" target="_blank")
         b-icon(icon="github")
-        |  Github
+        |  GitHub
     
     #nav
       router-link(to="/") Home

--- a/homebridge-ui/ui/src/views/Home.vue
+++ b/homebridge-ui/ui/src/views/Home.vue
@@ -19,7 +19,7 @@
     #nav
       router-link(to="/") Home
       span(style="font-weight: bold !important;")  · 
-      router-link(to="/config" v-b-popover.hover.top="'This is the old (static) config.schema! With this it is not possible to dynamically display the inputs for a TV. Only for experienced.'" title="Attention") Configs
+      router-link(to="/config" v-b-popover.hover.top="'This is the old (static) config.schema! With this it is not possible to dynamically display the inputs for a TV. Only for experienced users.'" title="Attention") Configs
       span(style="font-weight: bold !important;")  · 
       router-link(to="/new") New 
       b-form-select.seelectTV(v-model="selected" :options="televisions", v-if="televisions.length")

--- a/homebridge-ui/ui/src/views/New.vue
+++ b/homebridge-ui/ui/src/views/New.vue
@@ -10,7 +10,7 @@
     #nav
       router-link(to="/") Home
       span(style="font-weight: bold !important;")  · 
-      router-link(to="/config" v-b-popover.hover.top="'This is the old (static) config.schema! With this it is not possible to dynamically display the inputs for a TV. Only for experienced.'" title="Attention") Configs
+      router-link(to="/config" v-b-popover.hover.top="'This is the old (static) config.schema! With this it is not possible to dynamically display the inputs for a TV. Only for experienced users.'" title="Attention") Configs
       span(style="font-weight: bold !important;")  · 
       router-link(to="/new") New
       

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "homebridge-bravia-tvos",
+  "displayName": "Homebridge Bravia TV OS",
   "version": "5.0.8",
   "description": "Homebridge plugin for Sony Bravia Android TVs",
   "main": "index.js",


### PR DESCRIPTION
This will appear as "Homebridge Bravia tvOS" instead of "Homebridge Bravia Tvos" in Homebridge Config X.